### PR TITLE
Make docker-compose.yml work with Ubuntu 16.04 versions of docker(-co…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "2"
 
 services:
   notebook:
@@ -6,9 +6,9 @@ services:
     ports:
       - 8888:8888
     volumes:
-      - .:/home/jovyan/developer:cached
-      - ../bayeslite:/home/jovyan/bayeslite:cached
-      - ../cgpm:/home/jovyan/cgpm:cached
-      - ../crosscat:/home/jovyan/crosscat:cached
-      - ../iventure:/home/jovyan/iventure:cached
-      - ../workshop-materials/latest-tutorials:/home/jovyan/work:cached
+      - .:/home/jovyan/developer:rw
+      - ../bayeslite:/home/jovyan/bayeslite:rw
+      - ../cgpm:/home/jovyan/cgpm:rw
+      - ../crosscat:/home/jovyan/crosscat:rw
+      - ../iventure:/home/jovyan/iventure:rw
+      - ../workshop-materials/latest-tutorials:/home/jovyan/work:rw


### PR DESCRIPTION
…mpose).

This commit makes the probcomp/developer environment runnable using the
versions of docker and docker-compose that live in Ubuntu 16.04LTS, which
is the offical release platform of the OS running _within_ the probcomp/notebok
Docker image itself.

I anticipate that pinning docker.io and docker-compose to these versions will
be significantly simpler than pinning them to any other version, since these
versions are guaranteed to exist by default in vanilla LTS release.

Package: docker.io (1.10.3-0ubuntu6)
  https://packages.ubuntu.com/xenial/docker.io

Package: docker-compose (1.5.2-1)
  https://packages.ubuntu.com/xenial/docker-compose