### PR TITLE
use edge packages by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2"
 
 services:
   notebook:
-    image: probcomp/notebook
+    image: probcomp/notebook:edge
     ports:
       - 8888:8888
     hostname: ${USER}-notebook


### PR DESCRIPTION
I'm thinking we probably want to use the `edge` image by default for developers. Since we now run integration tests before rebuilding `edge`, it should be safe to do this.